### PR TITLE
Use qs to parse query strings

### DIFF
--- a/app/steps/sendProxyRequest.js
+++ b/app/steps/sendProxyRequest.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const qs = require('qs');
+
 var chunkLength = require('../../lib/chunkLength');
 
 function sendProxyRequest(Container) {
@@ -54,7 +56,7 @@ function sendProxyRequest(Container) {
         if (contentType === 'x-www-form-urlencoded' || contentType === 'application/x-www-form-urlencoded') {
           try {
             var params = JSON.parse(body);
-            body = Object.keys(params).map(function(k) { return k + '=' + params[k]; }).join('&');
+            body = qs.stringify(params);
           } catch (e) {
             // bodyContent is not json-format
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "express-http-proxy",
-  "version": "1.6.2",
+  "name": "front-express-http-proxy",
+  "version": "1.6.2-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -227,6 +227,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
         }
       }
@@ -2042,10 +2048,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "range-parser": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "front-express-http-proxy",
-  "version": "1.6.2-1",
+  "version": "1.6.2-2",
   "description": "http proxy middleware for express",
   "engines": {
     "node": ">=6.0.0"
@@ -40,6 +40,7 @@
   "dependencies": {
     "debug": "^3.0.1",
     "es6-promise": "^4.1.1",
+    "qs": "^6.9.6",
     "raw-body": "^2.3.0"
   },
   "contributors": [


### PR DESCRIPTION
Query strings were not formatted correctly, `qs` handles special characters with `encodeURIComponent`.